### PR TITLE
ターゲットフレームワークを .NET 8.0 に更新

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "AupDotNet"]
-	path = AupDotNet
-	url = https://github.com/karoterra/AupDotNet

--- a/AviUtlScriptExtractor.sln
+++ b/AviUtlScriptExtractor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31129.286
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35707.178 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AviUtlScriptExtractor", "AviUtlScriptExtractor\AviUtlScriptExtractor.csproj", "{C98C0C63-080F-476B-B8A1-0E87A3B6BAEC}"
 EndProject
@@ -14,8 +14,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AupDotNet", "AupDotNet\src\AupDotNet\AupDotNet.csproj", "{A2010DC2-7FCE-4A5B-8EF8-280FD5A2575D}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,10 +24,6 @@ Global
 		{C98C0C63-080F-476B-B8A1-0E87A3B6BAEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C98C0C63-080F-476B-B8A1-0E87A3B6BAEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C98C0C63-080F-476B-B8A1-0E87A3B6BAEC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A2010DC2-7FCE-4A5B-8EF8-280FD5A2575D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A2010DC2-7FCE-4A5B-8EF8-280FD5A2575D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A2010DC2-7FCE-4A5B-8EF8-280FD5A2575D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A2010DC2-7FCE-4A5B-8EF8-280FD5A2575D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AviUtlScriptExtractor/AviUtlScriptExtractor.csproj
+++ b/AviUtlScriptExtractor/AviUtlScriptExtractor.csproj
@@ -11,11 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\AupDotNet\src\AupDotNet\AupDotNet.csproj" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Karoterra.AupDotNet" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AviUtlScriptExtractor/AviUtlScriptExtractor.csproj
+++ b/AviUtlScriptExtractor/AviUtlScriptExtractor.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.3.0</Version>


### PR DESCRIPTION
.NET 6 のサポート期間が終了したので、LTSである .NET 8 にターゲットフレームワークを更新した。
依存パッケージを更新した。
AupDotNet をサブモジュールとしておく必要がなくなったためサブモジュールを削除した。